### PR TITLE
Feature/test lint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - punchcard

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const gulp = require('gulp');
+
+require('punchcard-runner')(gulp, {
+  application: {
+    library: {
+      src: [
+        'src',
+      ],
+    }
+  },
+  tasks: {
+    nodemon: {
+      extension: 'js html yml'
+    },
+    watch: [
+      'browser-sync',
+      'js:watch',
+      'sass:watch',
+      'imagemin:watch',
+    ],
+  },
+});

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ A `figure` element with an `img` element and an optional `figcaption`.
   <figcaption>Foo image caption</figcaption>
 </figure>
 ```
+
+## npm scripts
+
+* `npm run lint` - lints Javascript
+* `npm run ava` - runs unit tests
+* `npm run nyc` - runs unit tests, then runs code coverage
+* `npm test` - runs `npm pretest` first, which runs the linting, then ava, then nyc

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
   description: 'A system-agnostic HTML pattern for a figure element containing an image',
   content: {
     figure: {
-      class: 'figure--image',
+      class: 'figure-image',
     },
     img: {
       alt: 'Foo Image',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/pattern-library/pattern-figure-image#readme",
   "devDependencies": {
-    "ava": "^0.19.1"
+    "ava": "^0.19.1",
+    "jsdom": "^10.1.0"
   },
   "dependencies": {},
   "ava": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "pretest": "npm run lint",
     "ava": "ava",
     "lint": "gulp lint",
-    "test": "npm run ava"
+    "nyc": "nyc --all npm run ava",
+    "test": "npm run nyc"
   },
   "repository": {
     "type": "git",
@@ -27,9 +28,17 @@
     "ava": "^0.19.1",
     "eslint-plugin-ava": "^4.2.0",
     "jsdom": "^10.1.0",
+    "nyc": "^10.3.2",
     "punchcard-runner": "^2.1.3"
   },
   "dependencies": {},
+  "nyc": {
+    "exclude": [
+      "tests/**/*",
+      "Gulpfile.js",
+      "coverage"
+    ]
+  },
   "ava": {
     "files": [
       "tests/*.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A system-agnostic HTML pattern for a figure element containing an image",
   "main": "index.js",
   "scripts": {
+    "pretest": "npm run lint",
     "ava": "ava",
+    "lint": "gulp lint",
     "test": "npm run ava"
   },
   "repository": {
@@ -23,7 +25,9 @@
   "homepage": "https://github.com/pattern-library/pattern-figure-image#readme",
   "devDependencies": {
     "ava": "^0.19.1",
-    "jsdom": "^10.1.0"
+    "eslint-plugin-ava": "^4.2.0",
+    "jsdom": "^10.1.0",
+    "punchcard-runner": "^2.1.3"
   },
   "dependencies": {},
   "ava": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A system-agnostic HTML pattern for a figure element containing an image",
   "main": "index.js",
   "scripts": {
+    "ava": "ava",
+    "test": "npm run ava"
   },
   "repository": {
     "type": "git",
@@ -20,7 +22,14 @@
   },
   "homepage": "https://github.com/pattern-library/pattern-figure-image#readme",
   "devDependencies": {
+    "ava": "^0.19.1"
   },
-  "dependencies": {
+  "dependencies": {},
+  "ava": {
+    "files": [
+      "tests/*.js"
+    ],
+    "failFast": false,
+    "tap": true
   }
 }

--- a/src/figure-image.html
+++ b/src/figure-image.html
@@ -1,4 +1,4 @@
-<figure class="figure--foo">
+<figure class="figure-image">
   <img src="https://unsplash.it/200/300" alt="Foo Image">
   <figcaption>Foo image caption</figcaption>
 </figure>

--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - punchcard/configurations/ava

--- a/tests/pattern.js
+++ b/tests/pattern.js
@@ -1,6 +1,5 @@
 import test from 'ava';
 import fs from 'fs';
-import path from 'path';
 import { JSDOM } from 'jsdom';
 
 import plugin from '../';
@@ -38,4 +37,4 @@ test('default pattern', t => {
   t.true(frag.querySelector('figcaption') !== null, 'has a figcaption element');
   t.is(frag.querySelector('figcaption').textContent, content.figcaption.content, 'figcaption has default content');
   t.is(frag.querySelector('figure').lastElementChild, frag.querySelector('figcaption'), 'figcaption is second element');
-})
+});

--- a/tests/pattern.js
+++ b/tests/pattern.js
@@ -1,24 +1,41 @@
 import test from 'ava';
 import fs from 'fs';
 import path from 'path';
+import { JSDOM } from 'jsdom';
 
-import pattern from '../';
+import plugin from '../';
+
+let pattern;
 
 /**
- * Tests covers the min requirements for a generic pattern
+ * Tests covers the min requirements for a pattern
  */
-test('Pattern exports', t => {
-  t.is(typeof pattern, 'object', 'pattern exports an object');
+test('plugin exports', t => {
+  t.is(typeof plugin, 'object', 'plugin exports an object');
 });
 
-test('Required properties', t => {
-  t.true(pattern.hasOwnProperty('name'), 'pattern has a name');
-  t.true(pattern.hasOwnProperty('description'), 'pattern has a description');
-  t.true(pattern.hasOwnProperty('content'), 'pattern has content');
-  t.true(pattern.hasOwnProperty('versions'), 'pattern has versions');
-  t.true(pattern.versions.hasOwnProperty('default'), 'pattern has a default version');
-  t.is(typeof pattern.versions.default, 'string', 'default version is a string');
-  t.is(pattern.versions.default, './src/figure-image.html', 'default version references correct file');
-  t.true(fs.existsSync(pattern.versions.default), 'referenced default file exists');
+test.serial('Required properties', t => {
+  t.true(plugin.hasOwnProperty('name'), 'plugin has a name');
+  t.true(plugin.hasOwnProperty('description'), 'plugin has a description');
+  t.true(plugin.hasOwnProperty('content'), 'plugin has content');
+  t.true(plugin.hasOwnProperty('versions'), 'plugin has versions');
+  t.true(plugin.versions.hasOwnProperty('default'), 'plugin has a default version');
+  t.is(typeof plugin.versions.default, 'string', 'default version is a string');
+  t.is(plugin.versions.default, './src/figure-image.html', 'default version references correct file');
+  t.true(fs.existsSync(plugin.versions.default), 'referenced default file exists');
+  pattern = fs.readFileSync(plugin.versions.default, 'utf8');
 });
 
+test('default pattern', t => {
+  const content = plugin.content;
+  const frag = JSDOM.fragment(pattern);
+
+  t.true(frag.querySelector('figure') !== null, 'has a figure element');
+  t.true(frag.querySelector('figure').classList.contains(content.figure.class), 'figure element has default className');
+  t.true(frag.querySelector('img') !== null, 'has an image element');
+  t.is(frag.querySelector('img').getAttribute('src'), content.img.src, 'image has default image url');
+  t.is(frag.querySelector('img').getAttribute('alt'), content.img.alt, 'image has default image alternate text');
+  t.true(frag.querySelector('figcaption') !== null, 'has a figcaption element');
+  t.is(frag.querySelector('figcaption').textContent, content.figcaption.content, 'figcaption has default content');
+  t.is(frag.querySelector('figure').lastElementChild, frag.querySelector('figcaption'), 'figcaption is second element');
+})

--- a/tests/pattern.js
+++ b/tests/pattern.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+import fs from 'fs';
+import path from 'path';
+
+import pattern from '../';
+
+/**
+ * Tests covers the min requirements for a generic pattern
+ */
+test('Pattern exports', t => {
+  t.is(typeof pattern, 'object', 'pattern exports an object');
+});
+
+test('Required properties', t => {
+  t.true(pattern.hasOwnProperty('name'), 'pattern has a name');
+  t.true(pattern.hasOwnProperty('description'), 'pattern has a description');
+  t.true(pattern.hasOwnProperty('content'), 'pattern has content');
+  t.true(pattern.hasOwnProperty('versions'), 'pattern has versions');
+  t.true(pattern.versions.hasOwnProperty('default'), 'pattern has a default version');
+  t.is(typeof pattern.versions.default, 'string', 'default version is a string');
+  t.is(pattern.versions.default, './src/figure-image.html', 'default version references correct file');
+  t.true(fs.existsSync(pattern.versions.default), 'referenced default file exists');
+});
+


### PR DESCRIPTION
This set up adds unit testing with ava, uses jsdom to parse and traverse the dom of a pattern, and nyc for code coverage. Scripts:

* `npm run lint` - lints Javascript
* `npm run ava` - runs unit tests
* `npm run nyc` - runs unit tests, then prints out a code coverage chart
* `npm test` - runs `npm pretest` first, which runs the linting, then ava, then nyc 

The cool thing about this PR? The testing I wrote found errors in my first commit in _both_ the default html and the default content.

---
Resolves https://github.com/pattern-library/pattern-library/issues/36

`DCO 1.1 Signed-off-by: Scott Nath <github@scottnath.com>`
